### PR TITLE
Add addVersion flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Below are all options that can be passed to the plugin:
 * `filename` This is the output filename which gets written your webpack build
   directory. The default is `3rdpartylicenses.txt`.
 * `includeUndefined` whether include packages without license or not. The default is `false`
+* `addVersion` whether include version string to output file or not. The default is `true`
 * `addLicenseText` whether include license text to output file or not. The default is `true`
 * `addUrl` whether include url to repository to output file or not. The default is `false`
 * `licenseFilenames` A list of license filenames to match, in order of priority.

--- a/index.js
+++ b/index.js
@@ -167,7 +167,11 @@ var licenseReader = {
 
 var licenseWriter = {
   format: function(mod) {
-    var formatted = mod.name + '@' + mod.version + ' ' + mod.license;
+    var formatted = mod.name;
+    if (this.addVersion) {
+      formatted += '@' + mod.version;
+    }
+    formatted += ' ' + mod.license;
     if (this.addUrl && !!mod.url) {
       formatted += ' ' + mod.url;
     }
@@ -258,6 +262,7 @@ var instance = function() {
     moduleCache: {},
     licenseTypeCache: {},
     addUrl: false,
+    addVersion: true,
     addLicenseText: true,
     includeUndefined: false,
     suppressErrors: false,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -464,6 +464,19 @@ test('plugin', function (t) {
     t.end();
   });
 
+  t.test('the plugin should exclude packages version if addVersion property is set to false', function (t) {
+    var opts = createOpts();
+    opts.addVersion = false;
+    opts.addLicenseText = false;
+    var stats = createStats();
+    var plugin = createPlugin(opts);
+    var compiler = createCompiler(stats);
+    plugin.apply(compiler);
+    var licenseFile = mockfs.readFileSync('/project1/dist/3rdpartylicenses.txt')
+      .toString('utf8');
+    t.equal(licenseFile, 'lib1 MIT\n\nlib2 ISC\n\nlib3 MIT\n\nlib4 MIT');
+    t.end();
+  });
 
   t.test('the plugin\'s output should not contain if addLicenseText is set to false', function (t) {
     var stats = {


### PR DESCRIPTION
The addVersion flag lets you omit dependency version numbers.  The use case is that we don't want to expose exact version numbers for security reasons.