### PR TITLE
Add a regex option to exclude packages from the output

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ Below is an annotated list of options that can be passed along with their defaul
   modulesDirectories: ['node_modules'], // directories to check for modules. Can be useful in case you organize your frontend and backend dependencies into separate directories.
   licenseTemplateDir: undefined, // directory containing sample license text files (e.g. MIT.txt) to use when a license file can't be found (default behavior just prints the license identifier). One place to get license files would be from https://github.com/spdx/license-list .
   licenseFileOverrides: undefined, // object whose keys are package names and values are license filenames. Useful in case a package has multiple license files and you want to pick a specific one.
-  licenseTypeOverrides: undefined // object whose keys are package names and values are license types. Useful in case a package does not specify a license field in its package.json.
+  licenseTypeOverrides: undefined, // object whose keys are package names and values are license types. Useful in case a package does not specify a license field in its package.json.
+  excludedPackages: undefined, // optional Regex indicating package names to exclude.
 }
 ```
 

--- a/src/ConstructedOptions.ts
+++ b/src/ConstructedOptions.ts
@@ -18,6 +18,7 @@ interface ConstructedOptions {
   additionalPackages: string[];
   buildRoot?: string;
   modulesDirectories: string[];
+  excludedPackages?: RegExp;
 }
 
 export { ConstructedOptions };

--- a/src/ErrorMessage.ts
+++ b/src/ErrorMessage.ts
@@ -9,7 +9,8 @@ enum ErrorMessage {
   NO_LICENSE_FILE = 'Could not find a license file for {0}, defaulting to license name found in package.json: {1}',
   INVALID_MODULES_DIRECTORIES = 'Invalid modulesDirectories option. If defined, it should be a nonempty array of strings.',
   NO_MODULE_DIRECTORY_FOUND_FOR_MODULE = 'Could not find package {0} in any module directory. Please check if this package exists in any of the directories defined by the modulesDirectories option.',
-  BUILD_ROOT_NOT_EXIST = 'Could not find the following specified build root: {0}'
+  BUILD_ROOT_NOT_EXIST = 'Could not find the following specified build root: {0}',
+  UNACCEPTABLE_EXCLUDED_PACKAGES_NOT_REGEX = 'The excludedPackages should be a regular expression',
 }
 
 export { ErrorMessage };

--- a/src/LicenseWebpackPlugin.ts
+++ b/src/LicenseWebpackPlugin.ts
@@ -45,6 +45,15 @@ class LicenseWebpackPlugin {
       );
     }
 
+    if (
+      options.excludedPackages !== undefined && 
+      options.excludedPackages !== null &&
+      !(options.excludedPackages instanceof RegExp)) {
+      throw new LicenseWebpackPluginError(
+        ErrorMessage.UNACCEPTABLE_EXCLUDED_PACKAGES_NOT_REGEX
+      );
+    }
+
     this.options = {
       ...{
         licenseFilenames: [
@@ -127,8 +136,8 @@ class LicenseWebpackPlugin {
         const fileCallback = (filename: string) => {
           const packageName = this.moduleProcessor.processFile(filename);
           if (packageName) {
-            chunkModuleMap[packageName] = true;
-            totalChunkModuleMap[packageName] = true;
+              chunkModuleMap[packageName] = true;
+              totalChunkModuleMap[packageName] = true;
           }
         };
 

--- a/src/ModuleProcessor.ts
+++ b/src/ModuleProcessor.ts
@@ -32,6 +32,10 @@ class ModuleProcessor {
     }
 
     const packageName: string = this.extractPackageName(filename, modulePrefix);
+    if (this.options.excludedPackages && this.options.excludedPackages.test(packageName)) {
+      return null;
+    }
+
     return this.processPackage(packageName, modulePrefix);
   }
 

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -18,6 +18,7 @@ interface Options {
   additionalPackages?: string[];
   buildRoot?: string;
   modulesDirectories?: string[];
+  excludedPackages?: RegExp;
 }
 
 export { Options };


### PR DESCRIPTION
I needed to add this so we can exclude internal packages from the license output. Have not been able to add tests yet due to the issue I reported earlier today. Wanted to send out the PR to get your opinion and see if you agree with the change.