### PR TITLE
Handle LICENCE files as well

### DIFF
--- a/src/LicenseWebpackPlugin.ts
+++ b/src/LicenseWebpackPlugin.ts
@@ -53,7 +53,13 @@ class LicenseWebpackPlugin {
           'LICENSE.txt',
           'license',
           'license.md',
-          'license.txt'
+          'license.txt',
+          'LICENCE',
+          'LICENCE.md',
+          'LICENCE.txt',
+          'licence',
+          'licence.md',
+          'licence.txt'
         ],
         perChunkOutput: true,
         outputTemplate: path.resolve(__dirname, '../output.template.ejs'),

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -71,6 +71,13 @@ function oneLibProjectWithLicenseTxtFile() {
   return fixture;
 }
 
+function oneLibProjectWithLicenceFile() {
+  var fixture = oneLibProject();
+  delete fixture.fs['/project1/node_modules/lib1/LICENSE'];
+  fixture.fs['/project1/node_modules/lib1/LICENCE'] = 'MIT License';
+  return fixture;
+}
+
 function unknownLicenseProject() {
   var fixture = oneLibProject();
   fixture.fs['/project1/node_modules/lib1/package.json'] = JSON.stringify({
@@ -236,6 +243,7 @@ module.exports = {
   hasNonJsOutputProject: hasNonJsOutputProject,
   multiModuleVaryingLicenseProject: multiModuleVaryingLicenseProject,
   oneLibProjectWithLicenseTxtFile: oneLibProjectWithLicenseTxtFile,
+  oneLibProjectWithLicenceFile: oneLibProjectWithLicenceFile,
   unknownLicenseProject: unknownLicenseProject,
   missingLicenseFileProject: missingLicenseFileProject,
   oneLibScopedPackageProject: oneLibScopedPackageProject,

--- a/test/license-webpack-plugin.test.js
+++ b/test/license-webpack-plugin.test.js
@@ -188,6 +188,20 @@ test('the plugin detects a license.txt file from a module', function(t) {
   t.end();
 });
 
+test('the plugin detects a LICENCE file from a module', function(t) {
+  var plugin = new LicenseWebpackPlugin({
+    pattern: /^.*$/
+  });
+  var compiler = setup(fixtures.oneLibProjectWithLicenceFile());
+  plugin.apply(compiler);
+  t.equal(
+    compiler.compilation.assets['main.licenses.txt'].text,
+    'lib1@0.0.1\nMIT\nMIT License'
+  );
+  teardown();
+  t.end();
+});
+
 test('the plugin allows custom array of license filenames to match', function(
   t
 ) {


### PR DESCRIPTION
The spelling "licence" arises outside the US (ref https://www.grammarly.com/blog/licence-license/), and certain projects bundle e.g. a `LICENCE` instead of a `LICENSE`, e.g. https://github.com/Raynos/after.