### PR TITLE
Preventing build crash for old packages using license objects

### DIFF
--- a/src/LicenseTextReader.ts
+++ b/src/LicenseTextReader.ts
@@ -14,14 +14,14 @@ class LicenseTextReader {
     private templateDir: string | undefined,
     private handleMissingLicenseText: ((
       packageName: string,
-      licenseType: string | null | Object
+      licenseType: string | null
     ) => string | null)
   ) {}
 
   readLicense(
     compilation: WebpackCompilation,
     module: Module,
-    license: string | null | Object
+    license: string | null
   ): string | null {
     if (this.textOverrides[module.name]) {
       return this.textOverrides[module.name];

--- a/src/LicenseTextReader.ts
+++ b/src/LicenseTextReader.ts
@@ -21,7 +21,7 @@ class LicenseTextReader {
   readLicense(
     compilation: WebpackCompilation,
     module: Module,
-    license: string | null
+    licenseType: string | null
   ): string | null {
     if (this.textOverrides[module.name]) {
       return this.textOverrides[module.name];

--- a/src/LicenseTextReader.ts
+++ b/src/LicenseTextReader.ts
@@ -14,14 +14,14 @@ class LicenseTextReader {
     private templateDir: string | undefined,
     private handleMissingLicenseText: ((
       packageName: string,
-      licenseType: string | null
+      licenseType: string | null | Object
     ) => string | null)
   ) {}
 
   readLicense(
     compilation: WebpackCompilation,
     module: Module,
-    licenseType: string | null
+    license: string | null | Object
   ): string | null {
     if (this.textOverrides[module.name]) {
       return this.textOverrides[module.name];
@@ -31,7 +31,9 @@ class LicenseTextReader {
       return this.readText(module.directory, this.fileOverrides[module.name]);
     }
 
-    if (licenseType && licenseType.indexOf('SEE LICENSE IN ') === 0) {
+    if (licenseType && 
+        typeof licenseType === "string" && 
+        licenseType.indexOf('SEE LICENSE IN ') === 0) {
       const filename = licenseType.split(' ')[3];
       return this.fileSystem.isFileInDirectory(filename, module.directory)
         ? this.readText(module.directory, filename)


### PR DESCRIPTION
This PR prevents a crash in case the repository uses a legacy package with a license defined as an object. For examples please see: https://docs.npmjs.com/files/package.json#license