### PR TITLE
Alphabetical sort order of modules when rendering

### DIFF
--- a/src/PluginOptionsReader.ts
+++ b/src/PluginOptionsReader.ts
@@ -21,6 +21,9 @@ class PluginOptionsReader {
       options.renderLicenses ||
       ((modules: LicenseIdentifiedModule[]) => {
         return `${modules
+          .sort((left, right) => {
+            return left.name < right.name ? -1 : 1;
+          })
           .reduce((file, module) => {
             return `${file}${module.name}${
               module.licenseId ? `\n${module.licenseId}` : ''


### PR DESCRIPTION
Added functionality to always sort the modules in alphabetical order. 
This avoid changes to any generated files, which might be under source control.