### PR TITLE
fix licenseTemplateDir file inclusion check

### DIFF
--- a/src/LicenseTextReader.ts
+++ b/src/LicenseTextReader.ts
@@ -53,13 +53,15 @@ class LicenseTextReader {
 
     if (this.templateDir) {
       const templateFilename = `${licenseType}.txt`;
+      const templateFilePath = this.fileSystem.join(
+        this.templateDir,
+        templateFilename
+      );
       if (
-        this.fileSystem.isFileInDirectory(templateFilename, this.templateDir)
+        this.fileSystem.isFileInDirectory(templateFilePath, this.templateDir)
       ) {
         return this.fileSystem
-          .readFileAsUtf8(
-            this.fileSystem.join(this.templateDir, templateFilename)
-          )
+          .readFileAsUtf8(templateFilePath)
           .replace(/\r\n/g, '\n');
       }
     }

--- a/src/__tests__/LicenseTextReader.test.ts
+++ b/src/__tests__/LicenseTextReader.test.ts
@@ -23,7 +23,7 @@ class FakeFileSystem implements FileSystem {
     return (
       filename === '/project/LICENSE' ||
       filename === 'custom_file.txt' ||
-      (directory === '/templates' && filename === 'MIT.txt')
+      (directory === '/templates' && filename === '/templates/MIT.txt')
     );
   }
 


### PR DESCRIPTION
Addresses: https://github.com/xz64/license-webpack-plugin/issues/63