### PR TITLE
Only run plugin from the parent compiler

### DIFF
--- a/src/WebpackCompilerHandler.ts
+++ b/src/WebpackCompilerHandler.ts
@@ -21,7 +21,7 @@ class WebpackCompilerHandler {
 
   handleCompiler(compiler: WebpackCompiler) {
     if (typeof compiler.hooks !== 'undefined') {
-      compiler.hooks.compilation.tap(
+      compiler.hooks.thisCompilation.tap(
         'LicenseWebpackPlugin',
         (compilation: WebpackCompilation) => {
           compilation.hooks.optimizeChunkAssets.tap(


### PR DESCRIPTION
Webpack configs which have plugins/loaders that create child compilations are causing this plugin to be run multiple times. By switching to thisCompilation, the work will only happen in the main compiler by default. If the work needs to happen in a child compiler, the plugin can be passed directly to the child compiler (see createChildCompiler here https://github.com/webpack/webpack/blob/498bb0841bd79476569701dc2e4f0f65dc87359c/lib/Compiler.js)