### PR TITLE
Re-use expensive stats object

### DIFF
--- a/src/PluginChunkReadHandler.ts
+++ b/src/PluginChunkReadHandler.ts
@@ -12,6 +12,7 @@ import { LicensePolicy } from './LicensePolicy';
 import { Module } from './Module';
 import { WebpackCompilation } from './WebpackCompilation';
 import { Logger } from './Logger';
+import { WebpackStats } from './WebpackStats';
 
 class PluginChunkReadHandler implements WebpackChunkHandler {
   private moduleIterator = new WebpackChunkModuleIterator();
@@ -29,9 +30,10 @@ class PluginChunkReadHandler implements WebpackChunkHandler {
   processChunk(
     compilation: WebpackCompilation,
     chunk: WebpackChunk,
-    moduleCache: ModuleCache
+    moduleCache: ModuleCache,
+    stats: WebpackStats | undefined
   ) {
-    this.moduleIterator.iterateModules(compilation, chunk, module => {
+    this.moduleIterator.iterateModules(compilation, chunk, stats, module => {
       this.fileIterator.iterateFiles(
         module,
         (filename: string | null | undefined) => {

--- a/src/WebpackChunkHandler.ts
+++ b/src/WebpackChunkHandler.ts
@@ -2,12 +2,14 @@ import { WebpackChunk } from './WebpackChunk';
 import { ModuleCache } from './ModuleCache';
 import { Module } from './Module';
 import { WebpackCompilation } from './WebpackCompilation';
+import { WebpackStats } from './WebpackStats';
 
 interface WebpackChunkHandler {
   processChunk(
     compilation: WebpackCompilation,
     chunk: WebpackChunk,
-    moduleCache: ModuleCache
+    moduleCache: ModuleCache,
+    stats: WebpackStats | undefined
   ): void;
   processModule(
     compilation: WebpackCompilation,

--- a/src/WebpackChunkModuleIterator.ts
+++ b/src/WebpackChunkModuleIterator.ts
@@ -9,18 +9,19 @@ class WebpackChunkModuleIterator {
   iterateModules(
     compilation: WebpackCompilation,
     chunk: WebpackChunk,
+    stats: WebpackStats | undefined,
     callback: ((module: WebpackChunkModule) => void)
   ): void {
-    if (typeof compilation.chunkGraph !== 'undefined') {
+    if (
+      typeof compilation.chunkGraph !== 'undefined' &&
+      typeof stats !== 'undefined'
+    ) {
       // webpack v5
       for (const module of compilation.chunkGraph.getChunkModulesIterable(
         chunk
       )) {
         callback(module);
       }
-      // the chunk graph does not contain ES modules
-      // use stats instead to find the ES module imports
-      const stats: WebpackStats = compilation.getStats().toJson();
       const statsModules = this.statsIterator.collectModules(stats, chunk.name);
       for (const module of statsModules) {
         callback(module);

--- a/src/__tests__/WebpackChunkIterator.test.ts
+++ b/src/__tests__/WebpackChunkIterator.test.ts
@@ -49,6 +49,7 @@ describe('chunk iterator', () => {
     iterator.iterateModules(
       new FakeCompilation(),
       new WebpackV2Chunk(),
+      undefined,
       mockCallback
     );
     expect(mockCallback.mock.calls.length).toBe(1);
@@ -60,6 +61,7 @@ describe('chunk iterator', () => {
     iterator.iterateModules(
       new FakeCompilation(),
       new WebpackV3Chunk(),
+      undefined,
       mockCallback
     );
     expect(mockCallback.mock.calls.length).toBe(1);
@@ -71,6 +73,7 @@ describe('chunk iterator', () => {
     iterator.iterateModules(
       new FakeCompilation(),
       new WebpackV4Chunk(),
+      undefined,
       mockCallback
     );
     expect(mockCallback.mock.calls.length).toBe(1);
@@ -96,6 +99,7 @@ describe('chunk iterator', () => {
     iterator.iterateModules(
       fakeCompilation,
       new WebpackV4Chunk(),
+      fakeCompilation.getStats().toJson(),
       mockCallback
     );
     expect(getChunkModules).toHaveBeenCalled();


### PR DESCRIPTION
Hi @xz64 -  thanks for your continued work on this plugin.

The recent change which calls getStats seems to cause a large perf regression in large projects. getStats is extremely expensive in large projects. Calling it repeatedly causes a huge spike in build time. I wrapped the toJson call in a console.time and received results as below. In large projects there are both (1) a large number of chunks, meaning the toJson will be called multiple times, and (2) a slower toJson.

![image](https://user-images.githubusercontent.com/16494982/104263342-4955d700-543e-11eb-959e-83ebfc8c8e01.png)

To resolve the issue, we just call toJson once and pass that instance around to inspect the results.

Fixes #92 

