### PR TITLE
fix: another case with module federation in windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "license-webpack-plugin",
-  "version": "2.3.14",
+  "version": "2.3.15",
   "description": "Outputs licenses from 3rd party libraries to a file",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/WebpackModuleFileIterator.ts
+++ b/src/WebpackModuleFileIterator.ts
@@ -35,7 +35,8 @@ class WebpackModuleFileIterator {
       !filename ||
       filename.indexOf('external ') === 0 ||
       filename.indexOf('container entry ') === 0 ||
-      filename.indexOf('ignored|') === 0
+      filename.indexOf('ignored|') === 0 ||
+      filename.indexOf('remote ') === 0
     ) {
       return null;
     }


### PR DESCRIPTION
Hi! first of all. Thanks for your amazing work.

Working with module federation and angular, I had some problems (only in windows, in mac and linux working as a charm) building and executing the serve. Watching related issues I was able to detect the problem. Using module federation as producer (exposing entries) was working with 2.3.14, but in the "consumer" (with the remotes option) causes an error trying to load some files that started with

"remote (default) webpack/container/reference/... ./Routing.module"

so I followed the code and included a similar condition for the "remote " case

If you consider it right and you could merge it and publish the version, you'll make my day, I have a demo in a few days 🗡️ 
Thank you very much!!