### PR TITLE
Registers Webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,5 +51,10 @@
   "dependencies": {
     "@types/webpack-sources": "^0.1.5",
     "webpack-sources": "^1.2.0"
+  },
+  "peerDependenciesMeta": {
+    "webpack": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
This PR adds `webpack` as an **optional** peer dependency (this is a new capability available in recent versions of Yarn / npm; it doesn't have any negative effect on older package managers, which will simply ignore the registration).

This is required because `license-webpack-plugin` may require Webpack on the following line:

https://github.com/xz64/license-webpack-plugin/blob/master/src/WebpackModuleFileIterator.ts#L48

Without the explicit registration, package managers may hoist Webpack in such a way that license-webpack-plugin will accidentally retrieve the wrong path. While it's not too dangerous in this case (at worst an incorrect log entry, from what I gather), it's good practice to make sure all dependencies are listed (especially as package managers tend to be stricter and may report this kind of patterns as errors if they detect it).

