### PR TITLE
perf: only include relevant information in stats output

### DIFF
--- a/src/WebpackCompilation.ts
+++ b/src/WebpackCompilation.ts
@@ -37,5 +37,12 @@ export interface WebpackCompilation {
   plugin?: (phase: string, callback: Function) => void;
   chunkGraph?: ChunkGraph;
   compiler: WebpackCompiler;
-  getStats: () => { toJson: () => WebpackStats };
+  getStats: () => { toJson: (options?: WebpackStatsOptions) => WebpackStats };
+}
+
+export interface WebpackStatsOptions {
+  all?: boolean;
+  chunks?: boolean;
+  chunkModules?: boolean;
+  nestedModules?: boolean;
 }

--- a/src/WebpackCompilerHandler.ts
+++ b/src/WebpackCompilerHandler.ts
@@ -42,7 +42,12 @@ class WebpackCompilerHandler {
               () => {
                 // the chunk graph does not contain ES modules
                 // use stats instead to find the ES module imports
-                const stats: WebpackStats = compilation.getStats().toJson();
+                const stats: WebpackStats = compilation.getStats().toJson({
+                  all: false,
+                  chunks: true,
+                  chunkModules: true,
+                  nestedModules: true
+                });
                 this.iterateChunks(compilation, compilation.chunks, stats);
               }
             );


### PR DESCRIPTION
Before:

<img width="2691" alt="Screenshot 2021-05-31 at 21 55 31" src="https://user-images.githubusercontent.com/123679/120240471-ed5ee400-c260-11eb-9fa3-4ea19c2184f6.png">

After:

<img width="1224" alt="Screenshot 2021-05-31 at 22 31 15" src="https://user-images.githubusercontent.com/123679/120240483-f2bc2e80-c260-11eb-90b3-d68a28e0ea1a.png">