### PR TITLE
When available, use resolve data already present in most modules

### DIFF
--- a/src/FileHandler.ts
+++ b/src/FileHandler.ts
@@ -4,6 +4,8 @@ interface FileHandler {
   getModule(
     filename: string | null | undefined
   ): LicenseIdentifiedModule | null;
+  isBuildRoot(filename: string): boolean;
+  isInModuleDirectory(filename: string): boolean;
 }
 
 export { FileHandler };

--- a/src/LicenseIdentifiedModule.ts
+++ b/src/LicenseIdentifiedModule.ts
@@ -2,9 +2,9 @@ import { Module } from './Module';
 import { PackageJson } from './PackageJson';
 
 interface LicenseIdentifiedModule extends Module {
-  packageJson: PackageJson;
-  licenseId: string | null;
-  licenseText: string | null;
+  packageJson?: PackageJson;
+  licenseId?: string | null;
+  licenseText?: string | null;
 }
 
 export { LicenseIdentifiedModule };

--- a/src/PluginChunkReadHandler.ts
+++ b/src/PluginChunkReadHandler.ts
@@ -69,7 +69,6 @@ class PluginChunkReadHandler implements WebpackChunkHandler {
       descriptionFileData: packageJson
     } = resolved;
     if (
-      resolved &&
       this.fileHandler.isInModuleDirectory(directory) &&
       !this.fileHandler.isBuildRoot(directory)
     ) {

--- a/src/PluginFileHandler.ts
+++ b/src/PluginFileHandler.ts
@@ -20,28 +20,30 @@ class PluginFileHandler implements FileHandler {
       : this.cache[filename];
   }
 
+  isInModuleDirectory(filename: string) {
+    if (this.modulesDirectories === null) return true;
+    if (filename === null || filename === undefined) return false;
+    let foundInModuleDirectory = false;
+    const resolvedPath = this.fileSystem.resolvePath(filename);
+    for (const modulesDirectory of this.modulesDirectories) {
+      if (
+        resolvedPath.startsWith(this.fileSystem.resolvePath(modulesDirectory))
+      ) {
+        foundInModuleDirectory = true;
+      }
+    }
+    return foundInModuleDirectory;
+  }
+
+  isBuildRoot(filename: string) {
+    return this.buildRoot === filename;
+  }
+
   private getModuleInternal(
     filename: string
   ): Partial<LicenseIdentifiedModule> | null {
-    if (filename === null || filename === undefined) {
-      return null;
-    }
-
-    if (this.modulesDirectories !== null) {
-      let foundInModuleDirectory = false;
-      for (const modulesDirectory of this.modulesDirectories) {
-        if (
-          this.fileSystem
-            .resolvePath(filename)
-            .startsWith(this.fileSystem.resolvePath(modulesDirectory))
-        ) {
-          foundInModuleDirectory = true;
-        }
-      }
-      if (!foundInModuleDirectory) {
-        return null;
-      }
-    }
+    if (filename === null || filename === undefined) return null;
+    if (!this.isInModuleDirectory(filename)) return null;
 
     const module = this.findModuleDir(filename);
 
@@ -78,7 +80,7 @@ class PluginFileHandler implements FileHandler {
       }
     }
 
-    if (this.buildRoot === dirOfModule) {
+    if (this.isBuildRoot(dirOfModule)) {
       return null;
     }
 

--- a/src/WebpackChunkHandler.ts
+++ b/src/WebpackChunkHandler.ts
@@ -1,6 +1,6 @@
 import { WebpackChunk } from './WebpackChunk';
 import { ModuleCache } from './ModuleCache';
-import { Module } from './Module';
+import { LicenseIdentifiedModule } from './LicenseIdentifiedModule';
 import { WebpackCompilation } from './WebpackCompilation';
 import { WebpackStats } from './WebpackStats';
 
@@ -15,7 +15,7 @@ interface WebpackChunkHandler {
     compilation: WebpackCompilation,
     chunk: WebpackChunk,
     moduleCache: ModuleCache,
-    module: Module
+    module: LicenseIdentifiedModule
   ): void;
 }
 

--- a/src/WebpackChunkModule.ts
+++ b/src/WebpackChunkModule.ts
@@ -1,5 +1,7 @@
+import { PackageJson } from './PackageJson';
+
 export interface WebpackChunkModule {
-  resource: string;
+  resource?: string;
   rootModule?: {
     resource?: string;
   };
@@ -8,4 +10,8 @@ export interface WebpackChunkModule {
   };
   fileDependencies?: string[];
   dependencies?: WebpackChunkModule[];
+  resourceResolveData?: {
+    descriptionFileRoot: string;
+    descriptionFileData: PackageJson;
+  };
 }

--- a/src/WebpackFileSystem.ts
+++ b/src/WebpackFileSystem.ts
@@ -18,8 +18,8 @@ class WebpackFileSystem implements FileSystem {
 
   pathExists(filename: string): boolean {
     try {
-      this.fs.statSync(filename);
-      return true;
+      const stat = this.fs.statSync(filename, { throwIfNoEntry: false });
+      return !!stat;
     } catch (e) {
       return false;
     }
@@ -44,7 +44,7 @@ class WebpackFileSystem implements FileSystem {
   isDirectory(dir: string): boolean {
     let isDir = false;
     try {
-      isDir = this.fs.statSync(dir).isDirectory();
+      isDir = this.fs.statSync(dir, { throwIfNoEntry: false }).isDirectory();
     } catch (e) {}
     return isDir;
   }

--- a/src/__tests__/WebpackInnerModuleIterator.test.ts
+++ b/src/__tests__/WebpackInnerModuleIterator.test.ts
@@ -1,12 +1,12 @@
-import { WebpackModuleFileIterator } from '../WebpackModuleFileIterator';
+import { WebpackInnerModuleIterator } from '../WebpackInnerModuleIterator';
 import {
   fakeRequireResolve,
   FAKE_REQUIRE_RESOLVE_OUTPUT
 } from './FakeRequireResolve';
 
-const iterator = new WebpackModuleFileIterator(fakeRequireResolve);
+const iterator = new WebpackInnerModuleIterator(fakeRequireResolve);
 
-describe('WebpackModuleFileIterator', () => {
+describe('WebpackInnerModuleIterator', () => {
   it('returns null for falsy filename', () => {
     expect(iterator.getActualFilename('')).toBeNull();
     expect(iterator.getActualFilename(null)).toBeNull();


### PR DESCRIPTION
All/most NormalModules carry their `resolveRequest` information along with them from the initial resolving of the module. When available, we can skip all our processing and fs access for those modules.

Doing so broke the current abstraction of a ModuleFileIterator, so I changed it to be an "inner module" iterator to more match what its doing.

You can see the typedef here
https://github.com/markjm/webpack/blob/16784692d3c3a8985327dd9a5665bf319d8aec1b/types.d.ts#L440-L448