### PR TITLE
fix: read license file from package directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.3] - 2022-07-XX
+### Fixed
+- Read "SEE LICENSE IN" file from package directory
+
 ## [4.0.2] - 2022-02-10
 ### Fixed
 - Fix regression when using dynamic imports

--- a/src/WebpackFileSystem.ts
+++ b/src/WebpackFileSystem.ts
@@ -8,7 +8,7 @@ class WebpackFileSystem implements FileSystem {
   constructor(private fs: any) {}
 
   isFileInDirectory(filename: string, directory: string): boolean {
-    const normalizedFile = this.resolvePath(filename);
+    const normalizedFile = this.resolvePath(this.join(directory, filename));
     const normalizedDirectory = this.resolvePath(directory);
     return (
       !this.isDirectory(normalizedFile) &&


### PR DESCRIPTION
Licenses that refer to external files ("SEE LICENSE IN") are currently skipped due to incorrect path resolution.

Here `resolvePath` resolves `normalizedFile` to the current working directory instead of `directory`.