### PR TITLE
License filename matching: check for word boundaries around the word 'license' or 'licence'

### DIFF
--- a/src/LicenseTextReader.ts
+++ b/src/LicenseTextReader.ts
@@ -85,10 +85,7 @@ class LicenseTextReader {
   ): string | null {
     for (const path of paths) {
       const filePath = this.fileSystem.join(modulePath, path);
-      if (
-        /\blicen[cs]e\b/i.test(path) &&
-        !this.fileSystem.isDirectory(filePath)
-      ) {
+      if (/^licen[cs]e/i.test(path) && !this.fileSystem.isDirectory(filePath)) {
         return path;
       }
     }

--- a/src/LicenseTextReader.ts
+++ b/src/LicenseTextReader.ts
@@ -88,7 +88,7 @@ class LicenseTextReader {
       if (this.fileSystem.isDirectory(filePath)) {
         continue;
       }
-      if (/^licen[cs]e/i.test(path)) {
+      if (/^licen[cs]e/i.test(path) || /\blicen[cs]e\b/i.test(path)) {
         return path;
       }
     }

--- a/src/LicenseTextReader.ts
+++ b/src/LicenseTextReader.ts
@@ -85,7 +85,10 @@ class LicenseTextReader {
   ): string | null {
     for (const path of paths) {
       const filePath = this.fileSystem.join(modulePath, path);
-      if (/^licen[cs]e/i.test(path) && !this.fileSystem.isDirectory(filePath)) {
+      if (this.fileSystem.isDirectory(filePath)) {
+        continue;
+      }
+      if (/^licen[cs]e/i.test(path)) {
         return path;
       }
     }

--- a/src/LicenseTextReader.ts
+++ b/src/LicenseTextReader.ts
@@ -85,11 +85,10 @@ class LicenseTextReader {
   ): string | null {
     for (const path of paths) {
       const filePath = this.fileSystem.join(modulePath, path);
-      if (this.fileSystem.isDirectory(filePath)) {
-        continue;
-      }
       if (/^licen[cs]e/i.test(path) || /\blicen[cs]e\b/i.test(path)) {
-        return path;
+        if (!this.fileSystem.isDirectory(filePath)) {
+          return path;
+        }
       }
     }
     return null;

--- a/src/LicenseTextReader.ts
+++ b/src/LicenseTextReader.ts
@@ -85,7 +85,10 @@ class LicenseTextReader {
   ): string | null {
     for (const path of paths) {
       const filePath = this.fileSystem.join(modulePath, path);
-      if (/^licen[cs]e/i.test(path) && !this.fileSystem.isDirectory(filePath)) {
+      if (
+        /\blicen[cs]e\b/i.test(path) &&
+        !this.fileSystem.isDirectory(filePath)
+      ) {
         return path;
       }
     }

--- a/src/__tests__/LicenseTextReader.test.ts
+++ b/src/__tests__/LicenseTextReader.test.ts
@@ -128,6 +128,26 @@ describe('the license text reader', () => {
     expect(licenseText).toBe('LICENSE-/project/license.txt');
   });
 
+  test('license files with a prefix are detected', () => {
+    const reader: LicenseTextReader = new LicenseTextReader(
+      logger,
+      new FakeFileSystem(['MIT-LICENSE.txt']),
+      {},
+      {},
+      null,
+      () => null
+    );
+    const licenseText = reader.readLicense(
+      new FakeCompilation(),
+      {
+        name: 'foo',
+        directory: '/project'
+      },
+      ''
+    );
+    expect(licenseText).toBe('LICENSE-/project/MIT-LICENSE.txt');
+  });
+
   test('license files with a suffix are detected', () => {
     const reader: LicenseTextReader = new LicenseTextReader(
       logger,


### PR DESCRIPTION
Resolves #126.